### PR TITLE
fix: `colorful-extra-color-keyword-functions` with list of modes

### DIFF
--- a/colorful-mode.el
+++ b/colorful-mode.el
@@ -946,7 +946,7 @@ This is intended to be used with `colorful-extra-color-keyword-functions'."
   (dolist (fn colorful-extra-color-keyword-functions)
     (cond
      ((and (listp fn)
-           (derived-mode-p (car fn)))
+           (cl-some #'derived-mode-p (ensure-list (car fn))))
       (if (listp (cdr fn))
           (dolist (fn-list (cdr fn))
             (funcall fn-list))


### PR DESCRIPTION
`colorful-extra-color-keyword-functions` is not work with list of modes. For example, default value for `colorful-extra-color-keyword-functions` will not add functions on `html-mode` and `css-mode`.

This PR fixes that.